### PR TITLE
Fix Get-NodeIP returning an Array Object and not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2024-09-11
+
+### Fixed
+
+- Fix Get-NodeIP returning an Array Object and not a string
+
 ## [0.2.5] - 2024-09-11
 
 ### Changed

--- a/Diagrammer.Core.psd1
+++ b/Diagrammer.Core.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Diagrammer.Core.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.5'
+ModuleVersion = '0.2.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Src/Private/Get-NodeIP.ps1
+++ b/Src/Private/Get-NodeIP.ps1
@@ -4,7 +4,7 @@ function Get-NodeIP {
         Used by Diagrammer to translate node name to an network ip address type object.
     .DESCRIPTION
     .NOTES
-        Version:        0.1.1
+        Version:        0.2.6
         Author:         Jonathan Colon
     .EXAMPLE
     .LINK
@@ -20,9 +20,12 @@ function Get-NodeIP {
                 } elseif ("InterNetworkV6" -in [System.Net.Dns]::GetHostAddresses($Hostname).AddressFamily) {
                     $IPADDR = ([System.Net.Dns]::GetHostAddresses($Hostname) | Where-Object { $_.AddressFamily -eq 'InterNetworkV6' }).IPAddressToString
                 } else {
-                    $IPADDR = 127.0.0.1
+                    $IPADDR = $Null
                 }
-            } catch { $null }
+            } catch {
+                Write-Verbose "Unable to resolve Hostname Address: $Hostname"
+                $IPADDR = $Null
+            }
             $NodeIP = Switch ([string]::IsNullOrEmpty($IPADDR)) {
                 $true { 'Unknown' }
                 $false { $IPADDR }


### PR DESCRIPTION
Fix Get-NodeIP returning an Array Object and not a string