### PR TITLE
v0.2.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.25] - 2025-05-04
+
+### Changed
+
+- Allow ValueFromPipeline in the Write-ColorOutput cmdlet
+- Bump version to 0.2.25
+
 ## [0.2.24] - 2025-04-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Allow ValueFromPipeline in the Write-ColorOutput cmdlet
-- Bump version to 0.2.25
+- Enable `ValueFromPipeline` support in the `Write-ColorOutput` cmdlet.
+- Update version to `0.2.25`.
+- Refine verbose messages in the `Add-WatermarkToImage` and `Export-Diagrammer` functions for improved clarity.
+- Enhance font size calculation in the `Add-WatermarkToImage` cmdlet for scenarios where no size is specified.
+
+### Fixed
+
+- Resolve an issue where watermarks were not being generated in base64 format.
 
 ## [0.2.24] - 2025-04-18
 

--- a/Diagrammer.Core.psd1
+++ b/Diagrammer.Core.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Diagrammer.Core.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.24'
+ModuleVersion = '0.2.25'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Src/Private/Export-Diagrammer.ps1
+++ b/Src/Private/Export-Diagrammer.ps1
@@ -179,7 +179,11 @@ function Export-Diagrammer {
             }
 
             if ($Format -eq "base64") {
-                ConvertTo-Base64 -ImageInput $DestinationPath
+                if (-Not $WaterMarkText) {
+                    ConvertTo-Base64 -ImageInput $Document
+                } else {
+                    ConvertTo-Base64 -ImageInput $DestinationPath
+                }
             } elseif ($Format -in @("jpg", "png")) {
                 if ($WaterMarkText) {
                     if ($Document) {

--- a/Src/Private/Resize-Image.ps1
+++ b/Src/Private/Resize-Image.ps1
@@ -1,41 +1,38 @@
+<#
+.SYNOPSIS
+    Resize an image
+.DESCRIPTION
+    Resize an image based on a new given height or width or a single dimension and a maintain ratio flag.
+    The execution of this CmdLet creates a new file named "OriginalName_resized" and maintains the original
+    file extension
+.PARAMETER Width
+    The new width of the image. Can be given alone with the MaintainRatio flag
+.PARAMETER Height
+    The new height of the image. Can be given alone with the MaintainRatio flag
+.PARAMETER ImagePath
+    The path to the image being resized
+.PARAMETER MaintainRatio
+    Maintain the ratio of the image by setting either width or height. Setting both width and height and also this parameter results in an error
+.PARAMETER Percentage
+   Resize the image *to* the size given in this parameter. It's imperative to know that this does not resize by the percentage but to the percentage of the image.
+.PARAMETER SmoothingMode
+    Sets the smoothing mode. Default is HighQuality.
+.PARAMETER InterpolationMode
+    Sets the interpolation mode. Default is HighQualityBicubic.
+.PARAMETER PixelOffsetMode
+    Sets the pixel offset mode. Default is HighQuality.
+.EXAMPLE
+    Resize-Image -Height 45 -Width 45 -ImagePath "Path/to/image.jpg"
+.EXAMPLE
+    Resize-Image -Height 45 -MaintainRatio -ImagePath "Path/to/image.jpg"
+.EXAMPLE
+    #Resize to 50% of the given image
+    Resize-Image -Percentage 50 -ImagePath "Path/to/image.jpg"
+.NOTES
+    Written By:
+    Christopher Walker
+#>
 Function Resize-Image() {
-    <#
-        .SYNOPSIS
-            Resize an image
-        .DESCRIPTION
-            Resize an image based on a new given height or width or a single dimension and a maintain ratio flag.
-            The execution of this CmdLet creates a new file named "OriginalName_resized" and maintains the original
-            file extension
-        .PARAMETER Width
-            The new width of the image. Can be given alone with the MaintainRatio flag
-        .PARAMETER Height
-            The new height of the image. Can be given alone with the MaintainRatio flag
-        .PARAMETER ImagePath
-            The path to the image being resized
-        .PARAMETER MaintainRatio
-            Maintain the ratio of the image by setting either width or height. Setting both width and height and also this parameter
-            results in an error
-        .PARAMETER Percentage
-        Resize the image *to* the size given in this parameter. It's imperative to know that this does not resize by the percentage but to the percentage of
-            the image.
-        .PARAMETER SmoothingMode
-            Sets the smoothing mode. Default is HighQuality.
-        .PARAMETER InterpolationMode
-            Sets the interpolation mode. Default is HighQualityBicubic.
-        .PARAMETER PixelOffsetMode
-            Sets the pixel offset mode. Default is HighQuality.
-        .EXAMPLE
-            Resize-Image -Height 45 -Width 45 -ImagePath "Path/to/image.jpg"
-        .EXAMPLE
-            Resize-Image -Height 45 -MaintainRatio -ImagePath "Path/to/image.jpg"
-        .EXAMPLE
-            #Resize to 50% of the given image
-            Resize-Image -Percentage 50 -ImagePath "Path/to/image.jpg"
-        .NOTES
-            Written By:
-            Christopher Walker
-    #>
-
     [CmdLetBinding(
         SupportsShouldProcess = $true,
         PositionalBinding = $false,
@@ -107,7 +104,7 @@ Function Resize-Image() {
             #Retrieving the best quality possible
             $NewImage.SmoothingMode = $SmoothingMode
             $NewImage.InterpolationMode = $InterpolationMode
-            $NewImage.PixelOffsetMode = $PixelOffsetMode
+            $NewImage.PixelOffsetMBitmapode = $PixelOffsetMode
             $NewImage.DrawImage($OldImage, $(New-Object -TypeName System.Drawing.Rectangle -ArgumentList 0, 0, $Width, $Height))
 
             If ($PSCmdlet.ShouldProcess("Resized image based on $Path", "save to $OutputPath")) {

--- a/Src/Private/Write-ColorOutput.ps1
+++ b/Src/Private/Write-ColorOutput.ps1
@@ -24,7 +24,8 @@ function Write-ColorOutput {
 
         [Parameter(
             Position = 1,
-            Mandatory = $true
+            Mandatory = $true,
+            ValueFromPipeline = $true
         )]
         [ValidateNotNullOrEmpty()]
         [String] $String


### PR DESCRIPTION
## [0.2.25] - 2025-05-04

### Changed

- Enable `ValueFromPipeline` support in the `Write-ColorOutput` cmdlet.
- Update version to `0.2.25`.
- Refine verbose messages in the `Add-WatermarkToImage` and `Export-Diagrammer` functions for improved clarity.
- Enhance font size calculation in the `Add-WatermarkToImage` cmdlet for scenarios where no size is specified.

### Fixed

- Resolve an issue where watermarks were not being generated in base64 format.