### PR TITLE
v0.2.25

### DIFF
--- a/.github/workflows/Pester.yml
+++ b/.github/workflows/Pester.yml
@@ -26,6 +26,6 @@ jobs:
         - name: dump test results
           shell: pwsh
           run: |
-              Write-Host 'Total Tests Executed...:  ${{ steps.test_module.outputs.total_count }}'
-              Write-Host 'Total Tests PASSED.....:  ${{ steps.test_module.outputs.passed_count }}'
-              Write-Host 'Total Tests FAILED.....:  ${{ steps.test_module.outputs.failed_count }}'
+              Write-Host -Message 'Total Tests Executed...:  ${{ steps.test_module.outputs.total_count }}'
+              Write-Host -Message 'Total Tests PASSED.....:  ${{ steps.test_module.outputs.passed_count }}'
+              Write-Host -Message 'Total Tests FAILED.....:  ${{ steps.test_module.outputs.failed_count }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update version to `0.2.25`.
 - Refine verbose messages in the `Add-WatermarkToImage` and `Export-Diagrammer` functions for improved clarity.
 - Enhance font size calculation in the `Add-WatermarkToImage` cmdlet for scenarios where no size is specified.
+- Refactor verbose output messages to use -Message parameter for consistency across functions
 
 ### Fixed
 

--- a/Src/Private/Add-WatermarkToImage.ps1
+++ b/Src/Private/Add-WatermarkToImage.ps1
@@ -127,7 +127,7 @@ function Add-WatermarkToImage {
             $Graphics.Dispose()
 
         } else {
-            Write-Information "Unable to add watermark to image!"
+            Write-Information -Message "Unable to add watermark to image!"
         }
     }
 
@@ -139,17 +139,17 @@ function Add-WatermarkToImage {
             $Bitmap.Dispose()
 
             if ($TempImageOutput) {
-                Write-Verbose "Successfully added watermark text to $ImageInput image."
+                Write-Verbose -Message "Successfully added watermark text to $ImageInput image."
                 if ($PSBoundParameters.ContainsKey('DestinationPath')) {
                     try {
                         Copy-Item -Path $TempImageOutput -Destination $DestinationPath
-                        Write-Verbose "Successfully replaced $DestinationPath with $TempImageOutput watermarked image."
+                        Write-Verbose -Message "Successfully replaced $DestinationPath with $TempImageOutput watermarked image."
                     } catch {
-                        Write-Verbose "Unable to replace $DestinationPath watermark image to $TempImageOutput diagram."
-                        Write-Debug $($_.Exception.Message)
+                        Write-Verbose -Message "Unable to replace $DestinationPath watermark image to $TempImageOutput diagram."
+                        Write-Debug -Message $($_.Exception.Message)
                     }
                 } else {
-                    Write-Verbose "Successfully watermark $ImageInput diagram."
+                    Write-Verbose -Message "Successfully watermark $ImageInput diagram."
                     Get-ChildItem -Path $TempImageOutput
                 }
             }

--- a/Src/Private/ConvertTo-Base64.ps1
+++ b/Src/Private/ConvertTo-Base64.ps1
@@ -37,20 +37,20 @@ function ConvertTo-Base64 {
         [Bool] $Delete = $true
     )
     process {
-        Write-Verbose "Trying to convert Graphviz object to Base64 format."
+        Write-Verbose -Message "Trying to convert Graphviz object to Base64 format."
         # Code used to output image to base64 format
         try {
             $Base64 = [convert]::ToBase64String((Get-Content $ImageInput -Encoding byte))
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to Base64 format."
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to Base64 format."
+            Write-Debug -Message $($_.Exception.Message)
         }
         if ($Base64) {
             if ($Delete) {
                 Write-Verbose -Message "Deleting Temporary PNG file: $($ImageInput)"
                 Remove-Item -Path $ImageInput
             }
-            Write-Verbose "Successfully converted Graphviz object to Base64 format."
+            Write-Verbose -Message "Successfully converted Graphviz object to Base64 format."
             return $Base64
         } else {
             Write-Verbose -Message "Deleting Temporary PNG file: $($ImageInput)"

--- a/Src/Private/ConvertTo-Dot.ps1
+++ b/Src/Private/ConvertTo-Dot.ps1
@@ -31,19 +31,19 @@ function ConvertTo-Dot {
     )
     process {
         if ($WaterMarkText) {
-            Write-ColorOutput -Color 'Red' -String "WaterMark option is not supported with the dot format."
+            Write-Verbose -Message "WaterMark option is not supported with the dot format."
         }
 
         try {
-            Write-Verbose "Trying to convert Graphviz object to DOT format. Destination Path: $DestinationPath."
+            Write-Verbose -Message "Trying to convert Graphviz object to DOT format. Destination Path: $DestinationPath."
             $Document = Export-PSGraph -Source $GraphObj -DestinationPath $DestinationPath -OutputFormat 'dot' -GraphVizPath $GraphvizPath
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to DOT format."
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to DOT format."
+            Write-Debug -Message $($_.Exception.Message)
         }
         if ($Document) {
             if ($Document) {
-                Write-Verbose "Successfully converted Graphviz object to DOT format. Saved Path: $DestinationPath."
+                Write-Verbose -Message "Successfully converted Graphviz object to DOT format. Saved Path: $DestinationPath."
                 Get-ChildItem -Path $Document
             }
         }

--- a/Src/Private/ConvertTo-Jpg.ps1
+++ b/Src/Private/ConvertTo-Jpg.ps1
@@ -31,15 +31,15 @@ function ConvertTo-Jpg {
     )
     process {
         try {
-            Write-Verbose "Trying to convert Graphviz object to JPG format. Destination Path: $DestinationPath."
+            Write-Verbose -Message "Trying to convert Graphviz object to JPG format. Destination Path: $DestinationPath."
             $Document = Export-PSGraph -Source $GraphObj -DestinationPath $DestinationPath -OutputFormat 'jpg' -GraphVizPath $GraphvizPath
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to JPG format."
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to JPG format."
+            Write-Debug -Message $($_.Exception.Message)
         }
         if ($Document) {
             if ($Document) {
-                Write-Verbose "Successfully converted Graphviz object to JPG format. Saved Path: $DestinationPath."
+                Write-Verbose -Message "Successfully converted Graphviz object to JPG format. Saved Path: $DestinationPath."
                 Get-ChildItem -Path $Document
             }
         }

--- a/Src/Private/ConvertTo-Pdf.ps1
+++ b/Src/Private/ConvertTo-Pdf.ps1
@@ -31,15 +31,15 @@ function ConvertTo-Pdf {
     )
     process {
         try {
-            Write-Verbose "Trying to convert Graphviz object to PDF format. Destination Path: $DestinationPath."
+            Write-Verbose -Message "Trying to convert Graphviz object to PDF format. Destination Path: $DestinationPath."
             $Document = Export-PSGraph -Source $GraphObj -DestinationPath $DestinationPath -OutputFormat 'pdf' -GraphVizPath $GraphvizPath
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to PNG format."
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to PNG format."
+            Write-Debug -Message $($_.Exception.Message)
         }
         if ($Document) {
             if ($Document) {
-                Write-Verbose "Successfully converted Graphviz object to PDF format. Saved Path: $DestinationPath."
+                Write-Verbose -Message "Successfully converted Graphviz object to PDF format. Saved Path: $DestinationPath."
                 Get-ChildItem -Path $Document
             }
         }

--- a/Src/Private/ConvertTo-Png.ps1
+++ b/Src/Private/ConvertTo-Png.ps1
@@ -31,15 +31,15 @@ function ConvertTo-Png {
     )
     process {
         try {
-            Write-Verbose "Trying to convert Graphviz object to PNG format. Destination Path: $DestinationPath."
+            Write-Verbose -Message "Trying to convert Graphviz object to PNG format. Destination Path: $DestinationPath."
             $Document = Export-PSGraph -Source $GraphObj -DestinationPath $DestinationPath -OutputFormat 'png' -GraphVizPath $GraphvizPath
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to PNG format."
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to PNG format."
+            Write-Debug -Message $($_.Exception.Message)
         }
         if ($Document) {
             if ($Document) {
-                Write-Verbose "Successfully converted Graphviz object to PNG format. Saved Path: $DestinationPath."
+                Write-Verbose -Message "Successfully converted Graphviz object to PNG format. Saved Path: $DestinationPath."
                 Get-ChildItem -Path $Document
             }
         }

--- a/Src/Private/ConvertTo-RotateImage.ps1
+++ b/Src/Private/ConvertTo-RotateImage.ps1
@@ -73,17 +73,17 @@ function ConvertTo-RotateImage {
             $RotatedIMG.Dispose()
 
             if ($TempImageOutput) {
-                Write-Verbose "Successfully rotated $ImageInput image."
+                Write-Verbose -Message "Successfully rotated $ImageInput image."
                 if ($PSBoundParameters.ContainsKey('DestinationPath')) {
                     try {
                         Copy-Item -Path $TempImageOutput -Destination $DestinationPath
-                        Write-Verbose "Successfully replaced $DestinationPath with $TempImageOutput rotated image."
+                        Write-Verbose -Message "Successfully replaced $DestinationPath with $TempImageOutput rotated image."
                     } catch {
-                        Write-Verbose "Unable to replace $DestinationPath rotated image to $TempImageOutput diagram."
-                        Write-Debug $($_.Exception.Message)
+                        Write-Verbose -Message "Unable to replace $DestinationPath rotated image to $TempImageOutput diagram."
+                        Write-Debug -Message $($_.Exception.Message)
                     }
                 } else {
-                    Write-Verbose "Successfully rotated $ImageInput diagram."
+                    Write-Verbose -Message "Successfully rotated $ImageInput diagram."
                     Get-ChildItem -Path $TempImageOutput
                 }
             }

--- a/Src/Private/ConvertTo-Svg.ps1
+++ b/Src/Private/ConvertTo-Svg.ps1
@@ -39,11 +39,11 @@ function ConvertTo-Svg {
     process {
 
         try {
-            Write-Verbose "Trying to convert Graphviz object to SVG format. Destination Path: $DestinationPath."
+            Write-Verbose -Message "Trying to convert Graphviz object to SVG format. Destination Path: $DestinationPath."
             $Document = Export-PSGraph -Source $GraphObj -DestinationPath $DestinationPath -OutputFormat 'svg' -GraphVizPath $GraphvizPath
         } catch {
-            Write-Verbose "Unable to convert Graphviz object to SVG format"
-            Write-Debug $($_.Exception.Message)
+            Write-Verbose -Message "Unable to convert Graphviz object to SVG format"
+            Write-Debug -Message $($_.Exception.Message)
         }
 
         if ($Document) {
@@ -69,7 +69,7 @@ function ConvertTo-Svg {
                 }
             } else {
                 if ($Document) {
-                    Write-Verbose "Successfully converted Graphviz object to SVG format. Saved Path: $DestinationPath."
+                    Write-Verbose -Message "Successfully converted Graphviz object to SVG format. Saved Path: $DestinationPath."
                     Get-ChildItem -Path $Document
                 }
             }

--- a/Src/Private/Export-Diagrammer.ps1
+++ b/Src/Private/Export-Diagrammer.ps1
@@ -140,17 +140,17 @@ function Export-Diagrammer {
 
             if ($Format -eq "svg") {
                 if ($WaterMarkText) {
-                    Write-Verbose "WaterMark option is not supported with the svg format."
+                    Write-Verbose -Message "WaterMark option is not supported with the svg format."
                 }
                 ConvertTo-Svg -GraphObj $GraphObj -DestinationPath $DestinationPath -Angle $Rotate
             } elseif ($Format -eq "dot") {
                 if ($WaterMarkText) {
-                    Write-Verbose "WaterMark option is not supported with the dot format."
+                    Write-Verbose -Message "WaterMark option is not supported with the dot format."
                 }
                 ConvertTo-Dot -GraphObj $GraphObj -DestinationPath $DestinationPath
             } elseif ($Format -eq "pdf") {
                 if ($WaterMarkText) {
-                    Write-Verbose "WaterMark option is not supported with the pdf format."
+                    Write-Verbose -Message "WaterMark option is not supported with the pdf format."
                 }
                 ConvertTo-pdf -GraphObj $GraphObj -DestinationPath $DestinationPath
             } else {
@@ -169,8 +169,8 @@ function Export-Diagrammer {
                         $Document = ConvertTo-Jpg -GraphObj $GraphObj -DestinationPath $TempOutPut
                     }
                 } catch {
-                    Write-Verbose "Unable to convert Graphviz object to $tempFormat format. Path: $TempOutPut"
-                    Write-Debug $($_.Exception.Message)
+                    Write-Verbose -Message "Unable to convert Graphviz object to $tempFormat format. Path: $TempOutPut"
+                    Write-Debug -Message $($_.Exception.Message)
                 }
 
                 if ($WaterMarkText) {
@@ -206,7 +206,7 @@ function Export-Diagrammer {
                 Remove-Item -Path $Document
             }
             $Err = $_
-            Write-Error $Err
+            Write-Error -Message $Err
         }
     }
     end {}

--- a/Src/Private/Get-DiaHtmlSignatureTable.ps1
+++ b/Src/Private/Get-DiaHtmlSignatureTable.ps1
@@ -190,7 +190,7 @@ Function Get-DiaHtmlSignatureTable {
 
     $TR = ''
     foreach ($r in $Rows) {
-        Write-Verbose "Creating Node: $r"
+        Write-Verbose -Message "Creating Node: $r"
         if ($NoFontBold) {
             $TR += '<TR><TD valign="top" align="{0}" colspan="2"><FONT POINT-SIZE="{1}">{2}</FONT></TD></TR>' -f $Align, $FontSize, $r
         } else {

--- a/Src/Private/Get-DiaImagePercent.ps1
+++ b/Src/Private/Get-DiaImagePercent.ps1
@@ -49,8 +49,8 @@ function Get-DiaImagePercent {
             try {
                 $Image_FromStream = [System.Drawing.Image]::FromStream((New-Object System.IO.MemoryStream(, [convert]::FromBase64String($GraphObj))))
             } catch {
-                Write-Verbose "Unable to convert Graphviz object to base64 format needed to get image dimensions"
-                Write-Debug $($_.Exception.Message)
+                Write-Verbose -Message "Unable to convert Graphviz object to base64 format needed to get image dimensions"
+                Write-Debug -Message $($_.Exception.Message)
             }
 
             if ($Image_FromStream) {
@@ -60,15 +60,15 @@ function Get-DiaImagePercent {
                 }
                 return $ImagePrty
             } else {
-                Write-Verbose "Unable to validate image dimensions"
+                Write-Verbose -Message "Unable to validate image dimensions"
             }
         } else {
             $ImagePrty = @{}
             try {
                 $Image = [System.Drawing.Image]::FromFile((Get-ChildItem -Path $ImageInput).FullName)
             } catch {
-                Write-Verbose "Unable to validate image path needed to get image dimensions"
-                Write-Debug $($_.Exception.Message)
+                Write-Verbose -Message "Unable to validate image path needed to get image dimensions"
+                Write-Debug -Message $($_.Exception.Message)
             }
 
             if ($Image) {
@@ -78,7 +78,7 @@ function Get-DiaImagePercent {
                 }
                 return $ImagePrty
             } else {
-                Write-Verbose "Unable to validate image dimensions"
+                Write-Verbose -Message "Unable to validate image dimensions"
             }
         }
     }

--- a/Src/Private/Get-NodeIP.ps1
+++ b/Src/Private/Get-NodeIP.ps1
@@ -23,7 +23,7 @@ function Get-NodeIP {
                     $IPADDR = $Null
                 }
             } catch {
-                Write-Verbose "Unable to resolve Hostname Address: $Hostname"
+                Write-Verbose -Message "Unable to resolve Hostname Address: $Hostname"
                 $IPADDR = $Null
             }
             $NodeIP = Switch ([string]::IsNullOrEmpty($IPADDR)) {
@@ -32,7 +32,7 @@ function Get-NodeIP {
                 default { $Hostname }
             }
         } catch {
-            Write-Verbose $_.Exception.Message
+            Write-Verbose -Message $_.Exception.Message
         }
 
         return $NodeIP

--- a/Src/Private/Group-Node.ps1
+++ b/Src/Private/Group-Node.ps1
@@ -48,7 +48,7 @@ function Group-Node {
         [string] $Minlen = 1
     )
     process {
-        Write-Verbose "Trying to convert Graphviz object to Base64 format."
+        Write-Verbose -Message "Trying to convert Graphviz object to Base64 format."
         # Code used to output image to base64 format
         $Output = &{
             $Group = Split-array -inArray $InputObject -size $SplitinGroups

--- a/Src/Private/Resize-Image.ps1
+++ b/Src/Private/Resize-Image.ps1
@@ -65,7 +65,7 @@ Function Resize-Image() {
         }
 
         If ($Percentage -and $MaintainRatio) {
-            Write-Warning "The MaintainRatio flag while using the Percentage parameter does nothing"
+            Write-Warning -Message"The MaintainRatio flag while using the Percentage parameter does nothing"
         }
     }
     Process {

--- a/Src/Private/Write-ColorOutput.ps1
+++ b/Src/Private/Write-ColorOutput.ps1
@@ -1,48 +1,106 @@
+#!/usr/bin/env pwsh
 function Write-ColorOutput {
     <#
     .SYNOPSIS
-        Used by Diagrammer to output colored text.
+        Colored Write-Output
     .DESCRIPTION
-    .NOTES
-        Version:        0.1.1
-        Author:         Prateek Singh
+        Produce colored output on the console without compromising the expected Output object type.
+        Useful when showing info in the console host while avoiding producing strings in the output Objects.
     .EXAMPLE
+        C:\> ls -Force | Write-ColorOutput -f 'Green'
+    .EXAMPLE
+        Help about_foreach | Write-ColorOutput -f Green -b Black
+    .INPUTS
+        Parsable Object
+    .OUTPUTS
+        Default output object type.
     .LINK
+        Online version: https://github.com/chadnpc/CliStyler/blob/main/src/scripts/Console/Writers/Write-ColorOutput.ps1
+    .NOTES
+        #BUG: Some commands don't work! Example:
+        $list = foreach ($file in Get-ChildItem) { if ($file.length -gt 100) { $($file | Select-Object Name, @{l = 'Size'; e = { $_.Length } }) } }
+        $list | Write-ColorOutput -F Green -B Black
+        #BUG This command works:
+        Help about_foreach | Write-ColorOutput -f Green -b Black # but,
+        Get-Help about_foreach | Write-ColorOutput -f Green -b Black # Doesn't work!
     #>
-
-    [CmdletBinding()]
-    [OutputType([String])]
-
-    Param
-    (
-        [Parameter(
-            Position = 0,
-            Mandatory = $true
-        )]
-        [ValidateNotNullOrEmpty()]
-        [String] $Color,
-
-        [Parameter(
-            Position = 1,
-            Mandatory = $true,
-            ValueFromPipeline = $true
-        )]
-        [ValidateNotNullOrEmpty()]
-        [String] $String
+    [alias('Cecho', 'Out-Pipeline')]
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Name')]
+    param(
+        [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
+        [Alias('f')]
+        [ArgumentCompleter({
+                [OutputType([System.Management.Automation.CompletionResult])]
+                param(
+                    [string]$CommandName,
+                    [string]$ParameterName,
+                    [string]$WordToComplete,
+                    [System.Management.Automation.Language.CommandAst]$CommandAst,
+                    [System.Collections.IDictionary]$FakeBoundParameters
+                )
+                $CompletionResults = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
+                $([ConsoleColor].GetMembers() | Where-Object { $_.MemberType -eq 'Field' -and $null -eq $_.FieldHandle }).Name | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    $CompletionResults.Add([System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_))
+                }
+                return $CompletionResults
+            })]
+        [string]$ForegroundColor,
+        [Parameter(Mandatory = $false, ParameterSetName = 'Name')]
+        [Alias('b')]
+        [ArgumentCompleter({
+                [OutputType([System.Management.Automation.CompletionResult])]
+                param(
+                    [string]$CommandName,
+                    [string]$ParameterName,
+                    [string]$WordToComplete,
+                    [System.Management.Automation.Language.CommandAst]$CommandAst,
+                    [System.Collections.IDictionary]$FakeBoundParameters
+                )
+                $CompletionResults = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
+                $([ConsoleColor].GetMembers() | Where-Object { $_.MemberType -eq 'Field' -and $null -eq $_.FieldHandle }).Name | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+                    $CompletionResults.Add([System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_))
+                }
+                return $CompletionResults
+            })]
+        [string]$BackgroundColor,
+        # Object to write
+        [parameter(Mandatory = $false, ParameterSetName = 'Name', valueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, ValueFromRemainingArguments = $true)]
+        [Alias('i')]
+        [Object[]]$InputObject
     )
-    process {
-        # save the current color
-        $ForegroundColor = $Host.UI.RawUI.ForegroundColor
 
-        # set the new color
-        $Host.UI.RawUI.ForegroundColor = $Color
-
-        # output
-        if ($String) {
-            Write-Output $String
-        }
-
-        # restore the original color
-        $host.UI.RawUI.ForegroundColor = $ForegroundColor
+    begin {
+        $fc = $ExecutionContext.Host.UI.RawUI.ForegroundColor
+        $bc = $ExecutionContext.Host.UI.RawUI.BackgroundColor
     }
+    process {
+        $ConsoleColors = $([ConsoleColor].GetMembers() | Where-Object { $_.MemberType -eq 'Field' -and $null -eq $_.FieldHandle }).Name
+        try {
+            if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('ForegroundColor')) {
+                if ($ForegroundColor -in $ConsoleColors) {
+                    if ($PSCmdlet.ShouldProcess("Host.UI", "Set ForegroundColor")) { $ExecutionContext.Host.UI.RawUI.ForegroundColor = $ForegroundColor }
+                } else {
+                    $PSCmdlet.WriteWarning("$fxn Used Invalid ForegroundColor Parameter.")
+                }
+            }
+            if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey('BackgroundColor')) {
+                if ($BackgroundColor -in $ConsoleColors) {
+                    if ($PSCmdlet.ShouldProcess("Host.UI", "Set BackgroundColor")) { $ExecutionContext.Host.UI.RawUI.BackgroundColor = $BackgroundColor }
+                } else {
+                    $PSCmdlet.WriteWarning("$fxn Used Invalid BackgroundColor Parameter.")
+                }
+            }
+            $(if ($PSBoundParameters.Keys.Contains("InputObject")) { $InputObject } else { $input }) | ForEach-Object { Write-Output $_ }
+        } catch [System.Management.Automation.SetValueInvocationException] {
+            $ErrRecord = New-ErrorRecord -Exception [System.Management.Automation.SetValueInvocationException]::New('Invalid Color Name used. Take a walk, come back, then try using Tab Completion.')
+            $PSCmdlet.WriteError($ErrRecord)
+        } catch {
+            $PSCmdlet.WriteError([System.Management.Automation.ErrorRecord]$_)
+        } finally {
+            $ExecutionContext.Host.UI.RawUI.ForegroundColor = $fc
+            $ExecutionContext.Host.UI.RawUI.BackgroundColor = $bc
+        }
+    }
+
+    end {}
 }

--- a/Src/Public/New-Diagrammer.ps1
+++ b/Src/Public/New-Diagrammer.ps1
@@ -418,7 +418,7 @@ function New-Diagrammer {
         }
 
         if (($Format -ne "base64") -and !(Test-Path $OutputFolderPath)) {
-            Write-Error "OutputFolderPath '$OutputFolderPath' is not a valid folder path."
+            Write-Error -Message "OutputFolderPath '$OutputFolderPath' is not a valid folder path."
             break
         }
 
@@ -512,14 +512,14 @@ function New-Diagrammer {
 
             # Signature Section
             if ($Signature) {
-                Write-Verbose "Generating diagram signature"
+                Write-Verbose -Message "Generating diagram signature"
                 if ($CustomSignatureLogo) {
                     $Signature = (Get-DiaHtmlSignatureTable -ImagesObj $Images -Rows "Author: $($AuthorName)", "Company: $($CompanyName)" -TableBorder 2 -CellBorder 0 -Align 'left' -Logo $CustomSignatureLogo -IconDebug $IconDebug)
                 } else {
                     $Signature = (Get-DiaHtmlSignatureTable -ImagesObj $Images -Rows "Author: $($AuthorName)", "Company: $($CompanyName)" -TableBorder 2 -CellBorder 0 -Align 'left' -Logo "Logo_Footer" -IconDebug $IconDebug)
                 }
             } else {
-                Write-Verbose "No diagram signature specified"
+                Write-Verbose -Message "No diagram signature specified"
                 $Signature = " "
             }
 
@@ -546,7 +546,7 @@ function New-Diagrammer {
             if ($Graph) {
                 Export-Diagrammer -GraphObj ($Graph | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) -ErrorDebug $EnableErrorDebug -Format $OutputFormat -Filename "$Filename.$OutputFormat" -OutputFolderPath $OutputFolderPath -WaterMarkText $WaterMarkText -WaterMarkColor $WaterMarkColor -IconPath $IconPath
             } else {
-                Write-Verbose "No Graph object found. Disabling diagram section"
+                Write-Verbose -Message "No Graph object found. Disabling diagram section"
             }
         }
     }


### PR DESCRIPTION
## [0.2.25] - 2025-05-04

### Changed

- Enable `ValueFromPipeline` support in the `Write-ColorOutput` cmdlet.
- Update version to `0.2.25`.
- Refine verbose messages in the `Add-WatermarkToImage` and `Export-Diagrammer` functions for improved clarity.
- Enhance font size calculation in the `Add-WatermarkToImage` cmdlet for scenarios where no size is specified.
- Refactor verbose output messages to use -Message parameter for consistency across functions

### Fixed

- Resolve an issue where watermarks were not being generated in base64 format.